### PR TITLE
export Factory and GraphQLCustomScalarType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,14 @@ import {
   GraphQLDateTime,
   GraphQLUUID
 } from './scalars';
+import {
+  GraphQLCustomScalarType
+} from './types';
+import Factory from './factory';
 
 module.exports = {
+  Factory,
+  GraphQLCustomScalarType,
   GraphQLEmail,
   GraphQLURL,
   GraphQLLimitedString,


### PR DESCRIPTION
My proposed changes are to export Factory and GraphQLCustomScalarType to allow for easier creation of private custom types.