### PR TITLE
updating graphql peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tape": "^4.2.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.0 || ^0.7.0"
+    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0"
   },
   "keywords": [
     "es6",


### PR DESCRIPTION
updating graphql peer dependency to include ^0.8.0.  all tests pass.