### PR TITLE
Add support for GraphQL 15

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 build
 lib
 npm-debug.log
+package-lock.json
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
+dist: xenial
+os: linux
 language: node_js
+
 node_js:
+  - "14"
+  - "12"
   - "10"
   - "9"
   - "8"
   - "7.1"
   - "6.9"
-  - "5.12"
-  - "4.5"
+
 before_script:
-  - "npm install graphql@^${GRAPHQL_VERSION}"
+  - npm install graphql@^${GRAPHQL_VERSION}
 
 env:
   - GRAPHQL_VERSION=v0.6
@@ -20,3 +24,4 @@ env:
   - GRAPHQL_VERSION=v0.12
   - GRAPHQL_VERSION=v0.13
   - GRAPHQL_VERSION=v14.0
+  - GRAPHQL_VERSION=v15.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "graphql-custom-types",
   "repository": "stylesuxx/graphql-custom-types",
   "version": "1.5.1",
-  "description": "Collection of custom graphql types like Email, URL, password and many more",
+  "description": "Collection of custom GraphQL types like Email, URL, password and many more",
   "author": "Chris Landa <stylesuxx@gmail.com>",
   "license": "MIT",
   "main": "lib/index.js",
@@ -15,27 +15,24 @@
     "preversion": "npm test"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-eslint": "^8.2.1",
-    "babel-preset-env": "^1.6.1",
-    "eslint": "^4.16.0",
-    "tape": "^4.2.2"
+    "@babel/cli": "^7.10.4",
+    "@babel/core": "^7.10.4",
+    "@babel/node": "^7.10.4",
+    "@babel/preset-env": "^7.10.4",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^7.0.0",
+    "tape": "^4.11.0"
   },
   "peerDependencies": {
-    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "keywords": [
-    "es6",
-    "es2015",
     "GraphQL",
     "express-graphql",
     "GraphQL types"
   ],
   "engines": {
-    "node": ">= 4.5.0"
+    "node": ">= 6.9"
   },
-  "types": "./index.d.ts",
-  "dependencies": {
-    "graphql": "^14.4.2"
-  }
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
- Upgrade to latest dev deps (babel, eslint, tape)
- Add Node 12 & 14 to Travis
- Remove hard dependencies to GraphQL, must be on peerDependencies instead

Fix #28